### PR TITLE
Release 1.0.4

### DIFF
--- a/client-lib/pom.xml
+++ b/client-lib/pom.xml
@@ -27,7 +27,7 @@
 
     <!-- External dependencies -->
     <junit.version>[5.8.2]</junit.version>
-    <mockito-core.version>[4.5.1]</mockito-core.version>
+    <mockito-core.version>[4.6.1]</mockito-core.version>
     <jersey.version>[2.35]</jersey.version>
 
     <!-- Maven plugins -->

--- a/client-lib/src/main/java/com/signnow/library/dto/ApiError.java
+++ b/client-lib/src/main/java/com/signnow/library/dto/ApiError.java
@@ -1,13 +1,21 @@
 package com.signnow.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.signnow.library.dto.AuthError.Type;
 import java.util.List;
 
 @SuppressWarnings("java:S1104") // field name equal to JsonProperty
 public class ApiError {
+  public Type error;
   public List<ErrorInfo> errors;
 
   public static class ErrorInfo {
     public Integer code;
     public String message;
+  }
+
+  @JsonSetter("error")
+  public void setType(String type) {
+    this.error = Type.typeOf(type);
   }
 }


### PR DESCRIPTION
- added error field to ApiError (invalid token will result in null instead of deserialization failure)